### PR TITLE
MultiProduct Settings: substitute reply-to as well as email from

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -3,7 +3,7 @@
 return [
     'name' => 'Custom Email Settings',
     'description' => 'Additional settings for emails to use different api key',
-    'version' => '2.1.0',
+    'version' => '2.1.1',
     'author' => '1FF',
     'routes' => [
         'main' => [

--- a/Service/TransportFactory.php
+++ b/Service/TransportFactory.php
@@ -94,6 +94,7 @@ class TransportFactory
 
         if ($productSettings) {
             $message->setFrom($productSettings['from_email'], $productSettings['from_name']);
+            $message->setReplyTo($productSettings['from_email'], $productSettings['from_name']);
             $this->setTransportParams($productSettings['transport'], $productSettings['api_key']);
             return;
         }


### PR DESCRIPTION
Here is the fix to substitute also "reply-to" fields of the message, the same way as "email from"